### PR TITLE
Make Hashing.hashed constant-time

### DIFF
--- a/pyrival/strings/hashing.py
+++ b/pyrival/strings/hashing.py
@@ -26,8 +26,7 @@ class Hashing:
         )
 
     def get_hashes(self, length):
-        mod = self.mod
         return (
-            [(self.f_hash[i + length] - self.f_pow[length] * self.f_hash[i]) % mod for i in range(self._len - length + 1)],
-            [(self.s_hash[i + length] - self.s_pow[length] * self.s_hash[i]) % mod for i in range(self._len - length + 1)],
+            [(self.f_hash[i + length] - self.f_pow[length] * self.f_hash[i]) % self.mod for i in range(self._len - length + 1)],
+            [(self.s_hash[i + length] - self.s_pow[length] * self.s_hash[i]) % self.mod for i in range(self._len - length + 1)],
         )

--- a/pyrival/strings/hashing.py
+++ b/pyrival/strings/hashing.py
@@ -9,21 +9,25 @@ class Hashing:
     def __init__(self, s, mod=HMOD, base1=HBASE1, base2=HBASE2):
         self.mod, self.base1, self.base2 = mod, base1, base2
         self._len = _len = len(s)
-        f_hash, s_hash = [0] * (_len + 1), [0] * (_len + 1)
+        f_hash, f_pw = [0] * (_len + 1), [1] * (_len + 1)
+        s_hash, s_pw = f_hash[:], f_pw[:]
         for i in range(_len):
             f_hash[i + 1] = (base1 * f_hash[i] + s[i]) % mod
             s_hash[i + 1] = (base2 * s_hash[i] + s[i]) % mod
-        self.f_hash, self.s_hash = f_hash, s_hash
+            f_pw[i + 1] = (base1 * f_pw[i]) % mod
+            s_pw[i + 1] = (base2 * s_pw[i]) % mod
+        self.f_hash, self.f_pw = f_hash, f_pw
+        self.s_hash, self.s_pw = s_hash, s_pw
 
     def hashed(self, start, stop):
         return (
-            (self.f_hash[stop] - pow(self.base1, stop - start, self.mod) * self.f_hash[start]) % self.mod,
-            (self.s_hash[stop] - pow(self.base2, stop - start, self.mod) * self.s_hash[start]) % self.mod,
+            (self.f_hash[stop] - self.f_pw[stop - start] * self.f_hash[start]) % self.mod,
+            (self.s_hash[stop] - self.s_pw[stop - start] * self.s_hash[start]) % self.mod,
         )
 
     def get_hashes(self, length):
         mod = self.mod
-        pow_base1, pow_base2 = pow(self.base1, length, mod), pow(self.base2, length, mod)
-        f_hash = [(self.f_hash[i + length] - pow_base1 * self.f_hash[i]) % mod for i in range(self._len - length + 1)]
-        s_hash = [(self.s_hash[i + length] - pow_base2 * self.s_hash[i]) % mod for i in range(self._len - length + 1)]
-        return f_hash, s_hash
+        return (
+            [(self.f_hash[i + length] - self.f_pw[length] * self.f_hash[i]) % mod for i in range(self._len - length + 1)],
+            [(self.s_hash[i + length] - self.s_pw[length] * self.s_hash[i]) % mod for i in range(self._len - length + 1)],
+        )

--- a/pyrival/strings/hashing.py
+++ b/pyrival/strings/hashing.py
@@ -9,25 +9,25 @@ class Hashing:
     def __init__(self, s, mod=HMOD, base1=HBASE1, base2=HBASE2):
         self.mod, self.base1, self.base2 = mod, base1, base2
         self._len = _len = len(s)
-        f_hash, f_pw = [0] * (_len + 1), [1] * (_len + 1)
-        s_hash, s_pw = f_hash[:], f_pw[:]
+        f_hash, f_pow = [0] * (_len + 1), [1] * (_len + 1)
+        s_hash, s_pow = f_hash[:], f_pow[:]
         for i in range(_len):
             f_hash[i + 1] = (base1 * f_hash[i] + s[i]) % mod
             s_hash[i + 1] = (base2 * s_hash[i] + s[i]) % mod
-            f_pw[i + 1] = (base1 * f_pw[i]) % mod
-            s_pw[i + 1] = (base2 * s_pw[i]) % mod
-        self.f_hash, self.f_pw = f_hash, f_pw
-        self.s_hash, self.s_pw = s_hash, s_pw
+            f_pow[i + 1] = base1 * f_pow[i] % mod
+            s_pow[i + 1] = base2 * s_pow[i] % mod
+        self.f_hash, self.f_pow = f_hash, f_pow
+        self.s_hash, self.s_pow = s_hash, s_pow
 
     def hashed(self, start, stop):
         return (
-            (self.f_hash[stop] - self.f_pw[stop - start] * self.f_hash[start]) % self.mod,
-            (self.s_hash[stop] - self.s_pw[stop - start] * self.s_hash[start]) % self.mod,
+            (self.f_hash[stop] - self.f_pow[stop - start] * self.f_hash[start]) % self.mod,
+            (self.s_hash[stop] - self.s_pow[stop - start] * self.s_hash[start]) % self.mod,
         )
 
     def get_hashes(self, length):
         mod = self.mod
         return (
-            [(self.f_hash[i + length] - self.f_pw[length] * self.f_hash[i]) % mod for i in range(self._len - length + 1)],
-            [(self.s_hash[i + length] - self.s_pw[length] * self.s_hash[i]) % mod for i in range(self._len - length + 1)],
+            [(self.f_hash[i + length] - self.f_pow[length] * self.f_hash[i]) % mod for i in range(self._len - length + 1)],
+            [(self.s_hash[i + length] - self.s_pow[length] * self.s_hash[i]) % mod for i in range(self._len - length + 1)],
         )


### PR DESCRIPTION
As the title suggests, these changes makes calls to `Hashing.hashed` constant time by caching the relevant powers of hash bases.

The code has also been moved around a little to make it easier to remove the use of a second hash function.
This is useful in scenarios where we can afford a higher probability of collisions and we want higher performance.

Both of these optimisations are necessary for my hash-based solution to get an AC on [NVWLS](https://open.kattis.com/problems/nvwls).