### PR TITLE
Update LinkedList.py

### DIFF
--- a/pyrival/data_structures/LinkedList.py
+++ b/pyrival/data_structures/LinkedList.py
@@ -20,14 +20,14 @@ class LinkedList:
             self += iterable
 
     def get_node(self, index):
-        node = sentinel = self.sentinel
+        node = self.sentinel
         i = 0
         while i <= index:
             node = node.next
-            if node == sentinel:
+            if node == self.sentinel:
                 break
             i += 1
-        if node == sentinel:
+        if node == self.sentinel:
             node = None
         return node
 
@@ -65,26 +65,23 @@ class LinkedList:
         return elts
 
     def append(self, value):
-        sentinel = self.sentinel
         node = Node(value)
-        self.insert_between(node, sentinel.prev, sentinel)
+        self.insert_between(node, self.sentinel.prev, self.sentinel)
 
     def appendleft(self, value):
-        sentinel = self.sentinel
         node = Node(value)
-        self.insert_between(node, sentinel, sentinel.next)
+        self.insert_between(node, self.sentinel, self.sentinel.next)
 
     def insert(self, index, value):
-        sentinel = self.sentinel
         new_node = Node(value)
         len_ = len(self)
         if len_ == 0:
-            self.insert_between(new_node, sentinel, sentinel)
+            self.insert_between(new_node, self.sentinel, self.sentinel)
         elif index >= 0 and index < len_:
             node = self.get_node(index)
             self.insert_between(new_node, node.prev, node)
         elif index == len_:
-            self.insert_between(new_node, sentinel.prev, sentinel)
+            self.insert_between(new_node, self.sentinel.prev, self.sentinel)
         else:
             raise IndexError
         self.__len += 1
@@ -99,15 +96,13 @@ class LinkedList:
             raise IndexError
 
     def merge_left(self, other):
-        sentinel = self.sentinel
-        sentinel.next.prev = other.sentinel.prev
-        other.sentinel.prev.next = sentinel.next
-        sentinel.next = other.sentinel.next
-        sentinel.next.prev = sentinel
+        self.sentinel.next.prev = other.sentinel.prev
+        other.sentinel.prev.next = self.sentinel.next
+        self.sentinel.next = other.sentinel.next
+        self.sentinel.next.prev = self.sentinel
 
     def merge_right(self, other):
-        sentinel = self.sentinel
-        sentinel.prev.next = other.sentinel.next
-        other.sentinel.next.prev = sentinel.prev
-        sentinel.prev = other.sentinel.prev
-        sentinel.prev.next = sentinel
+        self.sentinel.prev.next = other.sentinel.next
+        other.sentinel.next.prev = self.sentinel.prev
+        self.sentinel.prev = other.sentinel.prev
+        self.sentinel.prev.next = self.sentinel

--- a/pyrival/data_structures/LinkedList.py
+++ b/pyrival/data_structures/LinkedList.py
@@ -32,7 +32,7 @@ class LinkedList:
         return node
 
     def __getitem__(self, index):
-        node = self.__get_node(index)
+        node = self.get_node(index)
         return node.value
 
     def __len__(self):
@@ -54,15 +54,25 @@ class LinkedList:
             self.__len -= 1
 
     def __repr__(self):
-        if not self:
-            return "{}()".format(self.__class__.__name__)
-        list_ = [self.__get_node(i).value for i in range(len(self))]
-        return "{}({})".format(self.__class__.__name__, list_)
+        return str(self.to_list())
+
+    def to_list(self):
+        elts = []
+        curr = self.sentinel.next
+        while curr != self.sentinel:
+            elts.append(curr.value)
+            curr = curr.next
+        return elts
 
     def append(self, value):
         sentinel = self.sentinel
         node = Node(value)
         self.insert_between(node, sentinel.prev, sentinel)
+
+    def appendleft(self, value):
+        sentinel = self.sentinel
+        node = Node(value)
+        self.insert_between(node, sentinel, sentinel.next)
 
     def insert(self, index, value):
         sentinel = self.sentinel
@@ -87,3 +97,17 @@ class LinkedList:
             right_node.prev = node
         else:
             raise IndexError
+
+    def merge_left(self, other):
+        sentinel = self.sentinel
+        sentinel.next.prev = other.sentinel.prev
+        other.sentinel.prev.next = sentinel.next
+        sentinel.next = other.sentinel.next
+        sentinel.next.prev = sentinel
+
+    def merge_right(self, other):
+        sentinel = self.sentinel
+        sentinel.prev.next = other.sentinel.next
+        other.sentinel.next.prev = sentinel.prev
+        sentinel.prev = other.sentinel.prev
+        sentinel.prev.next = sentinel


### PR DESCRIPTION
Fixed a __get_node typo, changed \_\_repr\_\_ method from O(n^2) to O(n), and implemented four new methods:
- to_list(): Converts Linked List to list in O(n).
- appendleft(value): Appends to the left in O(1).
- merge_left(other): Destructively merges another linked list on the left in O(1).
- merge_right(other): Destructively merges another linked list on the right in O(1).
