### PR TITLE
Switching to segtree based Dijkstra for extra speed

### DIFF
--- a/pyrival/graphs/dijkstra.py
+++ b/pyrival/graphs/dijkstra.py
@@ -1,18 +1,50 @@
-from heapq import heappop, heappush
+inf = -1
+def _min(a, b):
+    return a if b == inf or inf != a < b else b
 
+class DistanceKeeper:
+    def __init__(self, n):
+        self.m = 1
+        while self.m < n: self.m *= 2
+        self.data = 2 * m * [inf]
+        self.dist = n * [inf]
+        self.__getitem__ = self.dist.__getitem__ 
 
-def dijkstra(n, graph, start):
-    """ Uses Dijkstra's algortihm to find the shortest path between in a graph. """
-    dist, parents = [float("inf")] * n, [-1] * n
-    dist[start] = 0
+    def __setitem__(self, ind, x):
+        self.dist[ind] = x
 
-    queue = [(0, start)]
-    while queue:
-        path_len, v = heappop(queue)
-        if path_len == dist[v]:
-            for w, edge_len in graph[v]:
-                if edge_len + path_len < dist[w]:
-                    dist[w], parents[w] = edge_len + path_len, v
-                    heappush(queue, (edge_len + path_len, w))
+        ind += self.m
+        self.data[ind] = x
+        ind >>= 1
+        while ind:
+            self.data[ind] = _min(self.data[2 * ind], self.data[2 * ind + 1])
+            ind >>= 1
 
-    return dist, parents
+    def trav(self):
+        while self.data[1] != inf:
+            x = self.data[1]
+            
+            ind = 1
+            while ind < self.m:
+                ind = 2 * ind + (self.data[2 * ind] != x)
+            ind -= self.m
+
+            self[ind] = inf
+            self.dist[ind] = x
+            yield ind
+
+def dijkstra(self, graph, start):
+    n = len(graph)
+
+    P = [-1] * n
+    D = DistanceKeeper(n)
+    D[start] = 0
+    
+    for node in Dseg.trav():
+        for nei, weight in graph[node]:
+            new_dist = D[node] + weight
+            if D[nei] == inf or new_dist < D[nei]:
+                D[nei] = new_dist
+                P[nei] = node
+    
+    return D.dist, P

--- a/pyrival/graphs/dijkstra_heap.py
+++ b/pyrival/graphs/dijkstra_heap.py
@@ -1,0 +1,18 @@
+from heapq import heappop, heappush
+
+
+def dijkstra(n, graph, start):
+    """ Uses Dijkstra's algortihm to find the shortest path between in a graph. """
+    dist, parents = [float("inf")] * n, [-1] * n
+    dist[start] = 0
+
+    queue = [(0, start)]
+    while queue:
+        path_len, v = heappop(queue)
+        if path_len == dist[v]:
+            for w, edge_len in graph[v]:
+                if edge_len + path_len < dist[w]:
+                    dist[w], parents[w] = edge_len + path_len, v
+                    heappush(queue, (edge_len + path_len, w))
+
+    return dist, parents


### PR DESCRIPTION
Python has a problem with being slow when it comes to having tuples inside of a heap. There have been multiple problems on codeforces.com with currently no accepted python heap Dijkstra solutions. This PR adds a much more optimized Dijkstra using segment trees to get around using tuples and heaps. 