### PR TITLE
add version of bootstrap that transforms source

### DIFF
--- a/pyrival/misc/bootstrap_ast.py
+++ b/pyrival/misc/bootstrap_ast.py
@@ -56,6 +56,10 @@ class Bootstrap(ast.NodeTransformer):
 bootstrap = Bootstrap()
 
 
+def main():
+    pass
+
+
 if __name__ == "__main__":
     source = inspect.getsource(sys.modules[__name__])
     tree = bootstrap.visit(ast.parse(source))

--- a/pyrival/misc/bootstrap_ast.py
+++ b/pyrival/misc/bootstrap_ast.py
@@ -1,0 +1,66 @@
+import ast
+import inspect
+import sys
+from types import GeneratorType
+
+
+class Bootstrap(ast.NodeTransformer):
+    def __init__(self):
+        self.active = [False]
+        self.bootstrap = set()
+
+    @staticmethod
+    def resolve(to):
+        stack = []
+        while True:
+            if type(to) is GeneratorType:
+                stack.append(to)
+                to = next(to)
+            else:
+                stack.pop()
+                if not stack:
+                    break
+                to = stack[-1].send(to)
+        return to
+
+    def __call__(self, func):
+        self.bootstrap.add(func.__name__)
+
+    def visit_Call(self, node):
+        self.generic_visit(node)
+        if getattr(node.func, "id", None) in self.bootstrap:
+            if self.active[-1]:
+                return ast.Yield(node)
+            else:
+                return ast.Call(
+                   ast.Attribute(ast.Name("Bootstrap", ast.Load()), "resolve",
+                                 ast.Load()), [node], [])
+        return node
+
+    def visit_Return(self, node):
+        self.generic_visit(node)
+        return ast.Expr(ast.Yield(node.value)) if self.active[-1] else node
+
+    def visit_FunctionDef(self, node):
+        new_decorator_list = [
+            decorator for decorator in node.decorator_list
+            if getattr(decorator, "id", None) != "bootstrap"
+        ]
+        self.active.append(len(new_decorator_list) != len(node.decorator_list))
+        node.decorator_list = new_decorator_list
+        self.generic_visit(node)
+        self.active.pop()
+        return node
+
+
+bootstrap = Bootstrap()
+
+
+if __name__ == "__main__":
+    source = inspect.getsource(sys.modules[__name__])
+    tree = bootstrap.visit(ast.parse(source))
+    ast.fix_missing_locations(tree)
+    # print(ast.unparse(tree)) # for debugging
+    exec(compile(tree, __file__, "exec"), {})
+elif __name__ == "builtins":
+    main()


### PR DESCRIPTION
### Transformations it does

#### Inside bootstrapped function:

- convert `return` to `yield`
- add `yield` before calls to bootstrapped functions

#### Outside bootstrapped functions:

- remove `bootstrap` decorator
- pass result of bootstrapped function to `Bootstrap.resolve`

### Caveats

- all code will be executed twice can be avoided by wrapping it in `if __name__ == "builtins"`
- assigning bootstrapped functions to variable and calling the variables will cause problems, can be partially fixed by changing the implementation to:
  - using the bootstrap decorator instead of adding `Bootstrap.resolve` on all call outside bootstrapped functions or
  - outputting two function with one of them just being a wrapper to start the bootstrapping

  **Note:** These fixes only help for calls outside of bootstrapped function

### Example Transformation

<table>
  <tr>
    <th>Original</th>
    <th>Transformed</th>
  </tr>
  <tr>
    <td>

```python
@bootstrap
def abc1(n):
    if n == 0 or n == 1:
        return 1
    return abc2(n - 1) + n

@bootstrap
def abc2(n):
    if n == 0 or n == 1:
        return 1
    return abc1(n - 1) * n

def main():
    print(abc1(1000))
```
</td>
    <td>

```python
def abc1(n):
    if n == 0 or n == 1:
        yield 1
    yield ((yield abc2(n - 1)) + n)

def abc2(n):
    if n == 0 or n == 1:
        yield 1
    yield ((yield abc1(n - 1)) * n)

def main():
    print(Bootstrap.resolve(abc1(1000)))
```
</td>
  </tr>
</table>